### PR TITLE
trying patch for deactivation when exit a newly create env

### DIFF
--- a/conda_autoenv.sh
+++ b/conda_autoenv.sh
@@ -32,6 +32,8 @@ function conda_autoenv() {
           pip install -q -r requirements.txt
           echo "Pip requirements successfully installed"
         fi
+	# Set root directory of active environment
+	CONDA_ENV_ROOT="$(pwd)"
       fi
     fi
   elif [[ $PATH = */envs/* ]]\


### PR DESCRIPTION
Hi, not sure you take pull requests on this, but I noticed that conda-autenv failed to deactivate when exiting a newly created environment (and only on newly created by the script), e.g.: 
$mkdir test
$echo -e "name: test-env\ndependencies:\n - python>=3.5" > test/environment.yml
$ cd test/
Could not find conda environment: test-env
You can list all discoverable environments with `conda info --envs`.

Creating conda environment 'test-env' from environment.yml ('test-env' was not found using 'conda env list')
Collecting package metadata: ...working... done
Solving environment: ...working... done
Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
'test-env' successfully created and will automatically activate in this directory
(test-env) saulo@wireless-169-228-122-112:$
$cd ..
(test-env) saulo@wireless-169-228-122-112:$

This simple line I added inside the if seems to fix this.